### PR TITLE
buffing up one of the assertion msgs

### DIFF
--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -91,7 +91,11 @@ class TestRedirects(Base):
             product_alias['product_name'] == 'firefox-latest-euballot' and
             "download.allizom.org" in testsetup.base_url
         ):
-            Assert.equal(response.status_code, requests.codes.ok, 'Failed on %s \nUsing %s' % (url, param))
+            Assert.equal(response.status_code, requests.codes.ok,
+                'Redirect failed with HTTP status %s on %s \n \
+                For %s\n \
+                Redirected to %s' % \
+                (response.status_code, url, param, response.url))
             Assert.equal(parsed_url.scheme, 'http', 'Failed on %s \nUsing %s' % (url, param))
             Assert.equal(parsed_url.netloc, 'download.cdn.mozilla.net', 'Failed on %s \nUsing %s' % (url, param))
             if (


### PR DESCRIPTION
An attempt to improve an assertion failure msg for <code>test_redirect_for_firefox_aliases()</code>

AssertionError: Redirect failed with HTTP status 404 on https://download.allizom.org 
E                        For {'lang': 'en-US', 'product': 'firefox-latest', 'os': 'win'}
E                        Redirected to https://download.allizom.org/?product=firefox-16.0.1&os=win&lang=en-US
