### PR TITLE
Xfail neg test

### DIFF
--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -14,7 +14,8 @@ from base import Base
 
 class TestRedirects(Base):
 
-    @pytest.mark.xfail("config.getvalue('base_url') == 'http://download.allizom.org'")
+    @pytest.mark.xfail(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=801928", \
+        "config.getvalue('base_url') == 'http://download.allizom.org'")
     def test_that_checks_redirect_using_incorrect_query_values(self, testsetup):
         param = {
             'product': 'firefox-16.0b6',


### PR DESCRIPTION
Added an xfail to <code>test_that_checks_redirect_using_incorrect_query_values</code>. Test is known to fail when run against stage -- <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=801928">bug 801928</a>.
