### PR TITLE
We are testing bouncer, a redirection service. So when making bouncer

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -20,11 +20,24 @@ class Base:
                    'accept-language': locale}
 
         try:
-            return requests.head(url, headers=headers, verify=False, timeout=15,
-                                 params=params, allow_redirects=True)
+            r = requests.head(url, headers=headers, verify=False, timeout=15,
+                                 params=params, allow_redirects=False)
         except requests.RequestException as e:
             request_url = self._build_request_url(url, params)
+
             Assert.fail('Failing URL: %s.\nError message: %s' % (request_url, e))
+
+	if r.status_code == 302 and r.headers['Location']:
+	    try:
+		request_url = r.headers['Location']
+	        r = requests.head(request_url, headers=headers, verify=False, timeout=15,
+                                  params=params, allow_redirects=True)
+            except requests.RequestException as e:
+                request_url = self._build_request_url(url, params)
+
+                Assert.fail('Failing URL: %s.\nError message: %s' % (request_url, e))
+
+	return r
 
     def _parse_response(self, content):
         return BeautifulSoup(content)


### PR DESCRIPTION
requests, don't automatically traverse the first level of possible redirects,
but catch it and then follow it.

This way, if what we are being redirected to fails, that's what we'll report
on. Otherwise, this obscures what URL is failing/timing-out

This is not beautiful Python, my apologies, and I am sure it could be implemented more cleanly and generically. But as-is, this would at least allow pinpointing if it's bouncer or one of our CDNs causing the production Jenkins job to fail intermittently.
