### PR TITLE
Send Connection: close header on HEAD requests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -17,7 +17,8 @@ class Base:
     def _head_request(self, url, user_agent=_user_agent_firefox,
                       locale='en-US', params=None):
         headers = {'user-agent': user_agent,
-                   'accept-language': locale}
+                   'accept-language': locale,
+                   'Connection': 'close'}
 
         try:
             return requests.head(url, headers=headers, verify=False, timeout=15,


### PR DESCRIPTION
HEAD requests can behave oddly... if you don't explicitly tell the server it can close the connection after serving the request, it will sometimes leave the connection open, and eventually the client or server will time out.

You can test this directly, with curl:
curl -v -XHEAD 'http://download.mozilla.org/?lang=sw&product=firefox-16.0b6&os=osx' -o /dev/null
(hangs for a while after receiving the headers)
vs
curl -v -XHEAD -H 'Connection: close' 'http://download.mozilla.org/?lang=sw&product=firefox-16.0b6&os=osx' -o /dev/null
(exits immediately after receiving the headers)

In this case, I think we definitely want to be creating new connections for each request (not using keep-alives), so this is actually the proper way to do it in the first place. The RFC indicates that you should always send this header, unless you want to make additional requests on the same connection. We don't, so we should send it.
