### PR TITLE
Dont re-add request params when following a redirect

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -32,7 +32,7 @@ class Base:
 	    try:
 		request_url = r.headers['Location']
 	        r = requests.head(request_url, headers=headers, verify=False, timeout=15,
-                                  params=params, allow_redirects=True)
+                                  allow_redirects=True)
             except requests.RequestException as e:
                 Assert.fail('Failing URL: %s.\nError message: %s' % (request_url, e))
 


### PR DESCRIPTION
One last cleanup pull request. Don't re-add request params when following a redirect, it's incorrect.
