### PR TITLE
added ftp. removed misused endswith()

### DIFF
--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -212,10 +212,9 @@ class TestRedirects(Base):
                     response))
             )
             Assert.true(
-                parsed_url.netloc.endswith(
-                    ('download.cdn.mozilla.net', 'edgecastcdn.net',
-                        'download-installer.cdn.mozilla.net')
-                ),
+                parsed_url.netloc in ['download.cdn.mozilla.net', 'edgecastcdn.net',
+                        'download-installer.cdn.mozilla.net', 'ftp.mozilla.org']
+               ,
                 'Failed by redirected to incorrect host %s. \n %s' %
                 (parsed_url.netloc, self.response_info_failure_message(
                     base_url,


### PR DESCRIPTION
Two changes:
- Per conversations in #stubby with gozer and laura `ftp` is a trusted fallback mechanism
- We were misusing the `endswith()` method - https://docs.python.org/2/library/stdtypes.html#str.endswith - I've made a small a change that should correctly use the list of trusted `netlocs`
