### PR TITLE
Bug 1229852 - Make Firefox 40 win64 builds on the Release channel available on mozilla.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+venv

--- a/conftest.py
+++ b/conftest.py
@@ -95,7 +95,7 @@ LOCALES = (
     'zu'
 )
 
-OS = ('win', 'linux', 'osx')
+OS = ('win', 'win64', 'linux', 'linux64', 'osx')
 
 
 def pytest_generate_tests(metafunc):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [flake8]
 ignore=E501
+
+[pytest]
+norecursedirs = venv


### PR DESCRIPTION
We are adding win64 builds to https://www.mozilla.org/en-US/firefox/all/ (https://github.com/mozilla/bedrock/pull/3630). This PR adds win64 and linux64 to the tests. 