### PR TITLE
SHA1 stub tests

### DIFF
--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -60,6 +60,17 @@ class TestRedirects(Base):
         else:
             assert (product_alias + '.exe') in parsed_url.path
 
+    def test_ie6_vista_6_0_redirects_to_correct_version(self, base_url):
+        user_agent = ('Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 6.0; SV1; .NET CLR 2.0.50727)')
+        param = {
+            'product': 'firefox-stub',
+            'lang': 'en-US',
+            'os': 'win'
+        }
+        respsonse = self._head_request(base_url, user_agent=user_agent, params=param)
+        parsed_url = urlparse(respsonse.url)
+        assert '43.0.1.exe' in parsed_url.path
+
     def test_that_checks_redirect_using_incorrect_query_values(self, base_url):
         param = {
             'product': 'firefox-31.0',

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -18,6 +18,7 @@ class TestRedirects(Base):
         '38.5.3esr',
         '38.6.3esr',
         '40.0.0esr',
+        'stub',
         'latest',
         '42.0',
         '43.0.1',
@@ -51,7 +52,7 @@ class TestRedirects(Base):
         }
         response = self._head_request(base_url, user_agent=user_agent, params=param)
         parsed_url = urlparse(response.url)
-        if product_alias in ['latest', '44.0', '43.0.1']:
+        if product_alias in ['stub', 'latest', '44.0', '43.0.1']:
             assert '43.0.1.exe' in parsed_url.path
         elif 'esr' in product_alias:
             assert '38.5.1esr.exe' in parsed_url.path
@@ -67,8 +68,8 @@ class TestRedirects(Base):
             'lang': 'en-US',
             'os': 'win'
         }
-        respsonse = self._head_request(base_url, user_agent=user_agent, params=param)
-        parsed_url = urlparse(respsonse.url)
+        response = self._head_request(base_url, user_agent=user_agent, params=param)
+        parsed_url = urlparse(response.url)
         assert '43.0.1.exe' in parsed_url.path
 
     def test_that_checks_redirect_using_incorrect_query_values(self, base_url):


### PR DESCRIPTION
Post SHA1 shenanigans, the stub installer for XP and Vista now redirect to the 43.0.1.exe.

See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1235440'>Bug 1235440</a> for additional details.