### PR TITLE
remove travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python: 2.7
-install: "pip install flake8"
-script: "flake8 ."
-notifications:
-  email: webqa-ci@mozilla.org


### PR DESCRIPTION
Bouncer-tests have also been config'd off in https://travis-ci.org
